### PR TITLE
feature: set list style to square as in 50ohm 1.0

### DIFF
--- a/assets/style-course.css
+++ b/assets/style-course.css
@@ -170,6 +170,10 @@ td {
   text-align: justify;
 }
 
+ul {
+    list-style-type: square;
+}
+
 ul li::marker {
   color: #2aa6da;
 }


### PR DESCRIPTION
```
list-style-type: square;
```

In the old 50ohm.de 1.0 we had this list style. Just corrected it :-)