### PR TITLE
fix: add width to solution container

### DIFF
--- a/assets/style-course.css
+++ b/assets/style-course.css
@@ -261,6 +261,7 @@ span.formula {
   .course ul,
   .course ol,
   .course .question,
+  .course .solution,
   .course .table,
   .course .katex-display {
     width: 59.3%;


### PR DESCRIPTION
This PR fixes the solution button location on wide screens by adding the width attribute to the container around it.