### PR TITLE
fix: remove inline-block to improve display behaviour of morse code

### DIFF
--- a/assets/style-course.css
+++ b/assets/style-course.css
@@ -213,7 +213,6 @@ span.morse {
   font-size: 33%;
   position: relative;
   bottom: 1.7ex;
-  display: inline-block;
 }
 
 span.morse_char {


### PR DESCRIPTION
This PR fixes the issue #52, which only appears to be a problem in Safari. This fix also improves the behaviour of long morse strings when breaking lines.