### PR TITLE
Allow breadcrumbs within courses to grow up to 84% in width #35

### DIFF
--- a/assets/style-course.css
+++ b/assets/style-course.css
@@ -265,6 +265,9 @@ span.formula {
   .course .katex-display {
     width: 59.3%;
   }
+  .course .breadcrumb {
+    width: 82%;
+  }
 
   .course .margin {
     clear: right;


### PR DESCRIPTION
A greater width would potentially conflict with the three buttons (Video öffnen, Präsentationsfolien öffnen, Hilfsmittel herunterladen) at approx. 800px screen width. If the window is reduced further than 800px, the previous line break behavior remains unchanged.