### PR TITLE
fix: regex for picture references

### DIFF
--- a/renderer/picture.py
+++ b/renderer/picture.py
@@ -10,7 +10,7 @@ class Picture(SpanToken):
     """
 
     parse_inner = False
-    pattern = re.compile(r"\[picture:(\d+):(.+):(.+)\]")
+    pattern = re.compile(r"\[picture:(\d+):([^:]+):(.+)\]")
 
     def __init__(self, match_object):
         self.id = match_object.group(1)


### PR DESCRIPTION
Regular expressions are greedy. Placing a colon in the picture label will allow the first `(.+)` term to eat up more separator colons in the reference field.

See https://github.com/DARC-e-V/50ohm-contents-dl/issues/228