### PR TITLE
style: Change CSS for captions of pictures, images, and tables in slides

### DIFF
--- a/assets/style-slide.css
+++ b/assets/style-slide.css
@@ -294,6 +294,11 @@ section.has-dark-background h6 {
     border-bottom: none;
 }
 
+.reveal table caption {
+    caption-side: bottom;
+    font-size: 0.5em;
+}
+
 .reveal sup {
     vertical-align: super;
     font-size: smaller;
@@ -509,7 +514,7 @@ body:after {
 /* photos and pictures */
 .photo,
 .picture {
-    margin-bottom: 6ex;
+    margin-bottom: 1ex;
 }
 
 .photo img,

--- a/templates/slide/slide.html
+++ b/templates/slide/slide.html
@@ -11,7 +11,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="assets/reveal.js/dist/reset.css">
     <link rel="stylesheet" href="assets/reveal.js/dist/reveal.css">
-    <link rel="stylesheet" href="assets/style-slide.css">
+    <link rel="stylesheet" href="assets/style-slide.css?ts=202607091200">
     <!-- Theme used for syntax highlighting of code -->
     <link rel="stylesheet" href="assets/reveal.js/plugin/highlight/monokai.css">
     <!-- Chart plugin -->


### PR DESCRIPTION
* The caption for tables is now at the bottom in a smaller font size (the same like with pictures and images).
* The margin after a picture is now smaller, so that more can fit on one slide.
* Added a timestamp to the CSS like we do on the website, so that a browser would invalidate the cache after a change.
