### PR TITLE
Remove spurious s in page template

### DIFF
--- a/templates/html/page.html
+++ b/templates/html/page.html
@@ -139,7 +139,7 @@
                     <svg class="text-primary" xmlns="http://www.w3.org/2000/svg" width="1rem" height="1rem" fill="#FE756C" viewBox="0 0 512 512"><path d="M47.6 300.4L228.3 469.1c7.5 7 17.4 10.9 27.7 10.9s20.2-3.9 27.7-10.9L464.4 300.4c30.4-28.3 47.6-68 47.6-109.5v-5.8c0-69.9-50.5-129.5-119.4-141C347 36.5 300.6 51.4 268 84L256 96 244 84c-32.6-32.6-79-47.5-124.6-39.9C50.5 55.6 0 115.2 0 185.1v5.8c0 41.5 17.2 81.2 47.6 109.5z"/></svg></span>
                     vom <a class=link-secondary href="/infos.html#contributors">50ohm-Team</a> entwickelt
                   </div>
-                  <div class="mb-1">Ein Angebot des Deutschen Amateur-Radio-Clubs e.&nbsp;V.</div>
+                  <div class="mb-1">Ein Angebot des Deutschen Amateur-Radio-Club e.&nbsp;V.</div>
                   <div class="d-flex gap-2">
                       <a class="link-secondary" href="https://www.darc.de/der-club/referate/ajw/">Referat AJW</a>
                       &middot;


### PR DESCRIPTION
Der Vereinsname lautet offiziell Deutscher Amateur-Radio-Club e. V.  
Im Genitiv wird nur der Hauptbestandteil des Namens flektiert, also Deutscher → Deutschen. Der Wortteil Club bleibt unverändert, weil er Bestandteil des Eigennamens ist und Eigennamen im Genitiv häufig nicht weiter gebeugt werden.